### PR TITLE
Update readme for keystore file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To run Energi Gen 3 Core Node in a Docker container:
   cd /path/to/energi3-provisioning/Docker
   docker-compose up --detach
   ```
-
+- copy keystore file to `volumes\.energi3\keystore`
 - open the necessary ports for external inbound access in router and/or firewall:
   - `39797` TCP;
   - `39797` UDP;

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To run Energi Gen 3 Core Node in a Docker container:
   cd /path/to/energi3-provisioning/Docker
   docker-compose up --detach
   ```
-- copy keystore file to `volumes\.energi3\keystore`
+- copy keystore file to `/volumes/root/.energicore3/keystore`
 - open the necessary ports for external inbound access in router and/or firewall:
   - `39797` TCP;
   - `39797` UDP;


### PR DESCRIPTION
Updated the readme. You forgot to copy the keystore file to the correct directory.