### PR TITLE
Fix Currency bug

### DIFF
--- a/nodemon/scripts/nodemon.sh
+++ b/nodemon/scripts/nodemon.sh
@@ -97,7 +97,7 @@ function CTRL_C () {
 
  #+ Modified for `energi3-docker-compose`.
  #|if [[ -z "${CURRENCY}" ]]
- if [[ -z "${CURRENCY:=ECNM_CURRENCY}" ]]
+ if [[ -z "${CURRENCY:=$ECNM_CURRENCY}" ]]
  #+/ End of `energi3-docker-compose` modification.
  then
    CURRENCY=USD


### PR DESCRIPTION
Fix for small bug. in the info message i see the following line

`Mkt Price: ECNM_CURRENCY null`

Code was missing dollar sign in If statement