### PR TITLE
Add single source of Energi Core Node version

### DIFF
--- a/.env.template.env
+++ b/.env.template.env
@@ -1,3 +1,4 @@
 # https://docs.docker.com/compose/env-file/#compose-file-and-cli-variables
 # https://docs.docker.com/compose/reference/envvars/#compose_project_name
 COMPOSE_PROJECT_NAME=energi
+ENERGI_VERSION=v3.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM energicryptocurrency/energi3:v3.1.0
+ARG ENERGI_VERSION
+
+FROM energicryptocurrency/energi3:${ENERGI_VERSION}
 
 ENV USER_AND_GROUP_ID=1000
 ENV USERNAME=nrgstaker
@@ -6,13 +8,13 @@ ENV NRGSTAKER_HOME=/home/${USERNAME}
 
 WORKDIR ${NRGSTAKER_HOME}/energi3
 
-RUN addgroup --gid ${USER_AND_GROUP_ID} ${USERNAME} &&\
- adduser\
- --uid ${USER_AND_GROUP_ID} ${USERNAME}\
- --ingroup ${USERNAME}\
- --disabled-password &&\
- chown -R ${USERNAME}:${USERNAME} ${NRGSTAKER_HOME};\
- apk --no-cache add curl
+RUN addgroup --gid ${USER_AND_GROUP_ID} ${USERNAME} && \
+    adduser \
+    --uid ${USER_AND_GROUP_ID} ${USERNAME} \
+    --ingroup ${USERNAME} \
+    --disabled-password && \
+    chown -R ${USERNAME}:${USERNAME} ${NRGSTAKER_HOME}; \
+    apk --no-cache add curl
 
 COPY --chown=${USERNAME}:${USERNAME} ["scripts", "./"]
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,8 +1,12 @@
 # Energi Gen 3 Core Node in a Docker container using Docker Compose
 
-This repository is meant to ease running Energi Gen 3 Core Node in a Docker container using [Docker Compose](https://docs.docker.com/compose/) and the official [Energi Gen 3 image](https://hub.docker.com/r/energicryptocurrency/energi3).
+This repository is meant to ease running Energi Gen 3 Core Node in a Docker
+container using [Docker Compose](https://docs.docker.com/compose/) and the
+official
+[Energi Gen 3 image](https://hub.docker.com/r/energicryptocurrency/energi3).
 
-This repository was created with staking in mind. More adjustments may be necessary to run containerised Energi Gen 3 Core Node as a Masternode.
+This repository was created with staking in mind. More adjustments may be
+necessary to run containerised Energi Gen 3 Core Node as a Masternode.
 
 ---
 
@@ -13,6 +17,7 @@ This repository was created with staking in mind. More adjustments may be necess
   - [Bootstrap chaindata](#bootstrap-chaindata)
 - [Energi Core Node Monitor](#energi-core-node-monitor)
 - [Update](#update)
+- [Helper script](#helper-script)
 - [Credits](#credits)
 
 ---
@@ -23,46 +28,82 @@ Requirements to run a Energi 3 Core Node in a Docker container:
 
 - [Docker](https://docs.docker.com/engine/install/);
 - [Docker Compose](https://docs.docker.com/compose/install/);
-- enough free space to store blockchain data (as of mid April 2021 size of the data directory `.energicore3` is roughly 30 GB).
+- enough free space to store blockchain data (at the end of August 2021 size of
+  the data directory `.energicore3` is roughly 40 GB).
 
 ## Run Energi Core Node
 
 To run Energi Gen 3 Core Node in a Docker container:
 
-- clone this git repository: `git clone https://github.com/eandersons/energi3-docker-compose.git`;
+- clone this git repository:
+  `git clone https://github.com/eandersons/energi3-docker-compose.git`;
 - create the following files:
-  - `configs/energi3_account_address` that contains the Energi Gen 3 account address;
 
-    to add multiple accounts for staking, they must be specified as a comma separated list of addresses;
-  - `configs/energi3_account_password` that contains the Energi Gen 3 account password;
+  - `configs/energi3_account_address` that contains the Energi Gen 3 account
+    address;
 
-    to use multiple accounts for staking each password must be entered in a separate line in the same order addresses are specified in `configs/energi3_account_address`;
+    to add multiple accounts for staking, they must be specified as a comma
+    separated list of addresses;
 
-  these files are used to get account's address and password to automatically unlock account for staking when launching Energi Gen 3 Core Node;
+  - `configs/energi3_account_password` that contains the Energi Gen 3 account
+    password;
+
+    to use multiple accounts for staking each password must be entered in a
+    separate line in the same order addresses are specified in
+    `configs/energi3_account_address`; these files are used to get account's
+    address and password to automatically unlock account for staking when
+    launching Energi Gen 3 Core Node;
+
 - copy keystore file to `setup/.energicore3/keystore`;
 
-  > Note: a copy of keystore file should be stored in a safe place as the keystore file that will be placed in `setup/.energicore/keystore` will be moved to a Docker volume.
-- open the necessary ports for external inbound access in router and/or firewall:
+  > Note: a copy of keystore file should be stored in a safe place as the
+  > keystore file that will be placed in `setup/.energicore/keystore` will be
+  > moved to a Docker volume.
+
+- open the necessary ports for external inbound access in router and/or
+  firewall:
+
   - `39797` TCP;
   - `39797` UDP;
 
-  `39797` TCP and UDP ports are required for staking and Masternode as it is mentioned [here (section "1.7. Firewall Rules")](https://docs.energi.software/en/advanced/core-node-vps#h-17-firewall-rules);
-- optionally, to change the Docker Compose project name, `.env.template.env` should be copied and renamed to `.env` and if needed the value for [the CLI variable `COMPOSE_PROJECT_NAME`](https://docs.docker.com/compose/reference/envvars/#compose_project_name) should be changed to the desired value;
+  `39797` TCP and UDP ports are required for staking and Masternode as it is
+  mentioned
+  [here (section "1.7. Firewall Rules")](https://wiki.energi.world/en/advanced/core-node-vps#h-17-firewall-rules);
+
+- optionally, to change the Docker Compose project name, `.env.template.env`
+  should be copied and renamed to `.env` and if needed the value for
+  [the CLI variable `COMPOSE_PROJECT_NAME`](https://docs.docker.com/compose/reference/envvars/#compose_project_name)
+  should be changed to the desired value; by default `.env` with the content of
+  `.env.template.env` will be created automatically;
 - optionally, the Energi Core Node Monitor container can be enabled;
-  instructions on how to do it can be found in [`nodemon/ReadMe.md`](nodemon/ReadMe.md);
-- to move keystore file to the Energi data directory volume, bootstrap chaindata and start the Energi Gen 3 Core Node container the following command should be executed: `./e3dc setup core` (or `./e3dc setup` if Energi Core Node Monitor container should be set up and started as well and all the neccessary preparation for it has been done);
+  instructions on how to do it can be found in
+  [`nodemon/ReadMe.md`](nodemon/ReadMe.md);
+- to move keystore file to the Energi data directory volume, bootstrap chaindata
+  and start the Energi Gen 3 Core Node container the following command should be
+  executed: `./e3dc setup core` (or `./e3dc setup` if Energi Core Node Monitor
+  container should be set up and started as well and all the neccessary
+  preparation for it has been done);
 
   > `docker-compose` is used in `./e3dc setup` so `sudo` might be necessary.
 
-The aforementioned actions must be executed only once - when running Energi Core Node container for the first time. Later on container can be started with the command `docker-compose up --detach` or with the helper command `./e3dc start`.
+The aforementioned actions must be executed only once - when running Energi Core
+Node container for the first time. Later on container can be started with the
+command `docker-compose up --detach` or with the helper command `./e3dc start`.
 
-To check if Energi Core Node is running and account is unlocked for staking, the command `./e3dc status` should be executed. When Energi Core Node is fully synchronised, value under `nrg.syncing:` is `false` and value for `miner` and `staking` in the output under `miner.stakingStatus():` is `true`. If not, a block synchronisation might be in progress and `./e3dc status` should be executed after a while again to check if Energi Core Node is syncrhonised.
+To check if Energi Core Node is running and account is unlocked for staking, the
+command `./e3dc status` should be executed. When Energi Core Node is fully
+synchronised, value under `nrg.syncing:` is `false` and value for `miner` and
+`staking` in the output under `miner.stakingStatus():` is `true`. If not, a
+block synchronisation might be in progress and `./e3dc status` should be
+executed after a while again to check if Energi Core Node is syncrhonised.
 
 ## Troubleshooting
 
-General troubleshooting is described in the official [Energi troubleshooting guide](https://docs.energi.software/en/core-node-troubleshoot).
+General troubleshooting is described in the official
+[Energi troubleshooting guide](https://wiki.energi.world/en/core-node-troubleshoot).
 
-The following actions executed one by one might help if something goes sideways with chain synchronisation in Energi Gen 3 Core Node container:
+The following actions executed one by one might help if something goes sideways
+with chain synchronisation in Energi Gen 3 Core Node container:
 
 1. [apply preimages](#apply-preimages);
 
@@ -70,32 +111,68 @@ The following actions executed one by one might help if something goes sideways 
 
 2. [bootstrap chaindata](#bootstrap-chaindata).
 
-If applying preimages and bootstraping chaindata did not help, it might help if those actions are executed again. [Energi support](https://docs.energi.software/en/support/help-me) should be contacted if the problem is still persistent after multiple tries.
+If applying preimages and bootstraping chaindata did not help, it might help if
+those actions are executed again.
+[Energi support](https://wiki.energi.world/en/support/help-me) should be
+contacted if the problem is still persistent after multiple tries.
 
 ### Apply preimages
 
-Official Energi documentation: [Apply Preimages](https://docs.energi.software/en/core-node-troubleshoot#preimages).
+Official Energi documentation:
+[Apply Preimages](https://wiki.energi.world/en/core-node-troubleshoot#preimages).
 
-To apply preimages for Energi Gen 3 Core Node container the following command can be used: `./e3dc apply-preimages`.
+To apply preimages for Energi Gen 3 Core Node container the following command
+can be used: `./e3dc apply-preimages`.
 
-> `docker-compose` is used in `./e3dc apply-preimages` so `sudo` might be necessary.
+> `docker-compose` is used in `./e3dc apply-preimages` so `sudo` might be
+> necessary.
 
 ### Bootstrap chaindata
 
-Official Energi documentation: [Bootstrap Chaindata](https://docs.energi.software/en/core-node-troubleshoot#bootstrap).
+Official Energi documentation:
+[Bootstrap Chaindata](https://wiki.energi.world/en/core-node-troubleshoot#bootstrap).
 
-To bootstrap chaindata for Energi Core Node container the following command can be used: `./e3dc bootstrap-chaindata`.
+To bootstrap chaindata for Energi Core Node container the following command can
+be used: `./e3dc bootstrap-chaindata`.
 
-> `docker-compose` is used in `./e3dc bootstrap-chaindata` so `sudo` might be necessary.
+> `docker-compose` is used in `./e3dc bootstrap-chaindata` so `sudo` might be
+> necessary.
 
 ## Energi Core Node Monitor
 
-It is possible to enable Energi Core Node Monitor. Instructions on how to set it up are located in [nodemon/ReadMe.md](nodemon/ReadMe.md).
+It is possible to enable Energi Core Node Monitor. Instructions on how to set it
+up are located in [`nodemon/ReadMe.md`](nodemon/ReadMe.md).
 
 ## Update
 
-To get changes from the repository and update Energi Core Node images and containers the command `./e3dc update` should be executed.
-Or `./e3dc update core` or `./e3dc update monitor` to update image and container only for the specified service.
+To get changes from the repository and update Energi Core Node images and
+containers the command `./e3dc update` should be executed. Or
+`./e3dc update core` or `./e3dc update monitor` to update image and container
+only for the specified service.
+
+It is possible to build images and create containers for Energi Core Node
+versions other than the one specified in `.env.template.env`:
+`./e3dc update vX.Y.Z` or `./e3dc update core|monitor vX.Y.Z`. This may be
+especially useful for cases when a new version has been released but it has not
+been reflected in `.env.template.env` yet to update Energi Core Node (and
+Monitor) to the lateset version. Note that there is a chance that this command
+will fail (most probably because of an error while building Monitor image when
+the newest `energi3` veresion cannot be compiled using the Go version specified
+in `nodemon/Dockerfile`), and in such case the following commands should be
+executed:
+
+1. `./e3dc start core` to start core container as the image for the newest Core
+   version should be already built;
+2. `./e3dc update monitor` if Energi Core Node Monitor is used; this will use
+   the version that is specified in `.env.template.env`
+
+or `./e3dc update` to use Core and Monitor version specified in
+`.env.template.env` till isues are resolved in the repopsitory.
+
+## Helper script
+
+A little helper script `e3dc` is available. To see what it provides,
+`./e3dc help` should be executed.
 
 ## Credits
 
@@ -103,5 +180,8 @@ A list of tools and sources used in this repository:
 
 - [Docker Engine](https://docs.docker.com/engine/);
 - [Docker Compose](https://docs.docker.com/compose/);
-- [Energi Docker image](https://hub.docker.com/r/energicryptocurrency/energi3) (source: [Energi Core GitHub repository](https://github.com/energicryptocurrency/energi3) ([`containers/docker/master-alpine/Dockerfile`](https://github.com/energicryptocurrency/energi3/blob/master/containers/docker/master-alpine/Dockerfile)));
+- [Energi Docker image](https://hub.docker.com/r/energicryptocurrency/energi3)
+  (source:
+  [Energi Core GitHub repository](https://github.com/energicryptocurrency/energi3)
+  ([`containers/docker/master-alpine/Dockerfile`](https://github.com/energicryptocurrency/energi3/blob/master/containers/docker/master-alpine/Dockerfile)));
 - [Energi Core Node Monitor script `nodemon.sh`](https://github.com/energicryptocurrency/energi3-provisioning/blob/master/scripts/linux/nodemon.sh).

--- a/docker-compose.override.template.yml
+++ b/docker-compose.override.template.yml
@@ -1,12 +1,15 @@
 services:
   monitor:
-    build: nodemon
+    build:
+      args:
+        ENERGI_VERSION: ${ENERGI_VERSION}
+      context: nodemon
     depends_on:
       - core
     env_file: nodemon/.env
     environment:
       - TERM=xterm
-    image: energi-nodemon:3.1.0-1.1.1-0.0
+    image: energi-nodemon:${ENERGI_VERSION}-1.1.1-0.0
     restart: unless-stopped
     volumes:
       - core-data:/home/nrgstaker/.energicore3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: '3.8'
 
 secrets:
   account_address:
@@ -8,8 +8,12 @@ secrets:
 
 services:
   core:
-    build: .
-    image: energi-core:3.1.0-0.0
+    build:
+      args:
+        ENERGI_VERSION:
+          ${ENERGI_VERSION:?"`ENERGI_VERSION` must be set in `.env`!"}
+      context: .
+    image: energi-core:${ENERGI_VERSION}-0.0
     ports:
       - 39797:39797/tcp
       - 39797:39797/udp

--- a/e3dc
+++ b/e3dc
@@ -1,117 +1,298 @@
 #!/bin/sh
 
+command_pattern_attach='attach'
+command_pattern_chaindata='bootstrap-chaindata | chaindata'
+service_choices='core | monitor'
+command_pattern_console="console | shell | terminal ${service_choices}"
+command_pattern_preimages='apply-preimages | preimages'
+service_pattern="all | ${service_choices}"
+command_pattern_update="update [${service_pattern}] [<version>]"
+command_pattern_setup="setup [${service_pattern}]"
+command_pattern_start="start [${service_pattern}]"
+command_pattern_status='staking-status | status'
+env='.env'
+env_template='.env.template.env'
+help_description='Print this help message'
 help_message="\
 e3dc - a helper command for \`energi3-docker-compose\`, a dockerised Energi Core
 Node.
 
 Available commands:
-    apply-preimages, preimages      Apply preimages
-    attach                          Attach to Energi console
-    bootstrap-chaindata, chaindata  Bootstrap chaindata
-    help                            Print this help message
-    setup [all|core|monitor]        Setup Energi Core Node container(s)
-    start [all|core|monitor]        Start Energi Core Node container(s);
-        this is a shortcut for \`docker-compose up --detach [core|monitor]\`
-    status                          Energi Core Node synchronisation and staking
-        status
-    update [all|core|monitor]       Update image(s) and recreate container(s)
+    ${command_pattern_preimages}
+        Apply Energi Core Node preimages
+    ${command_pattern_attach}
+        Attach to the Energi Core Node console
+    ${command_pattern_chaindata}
+        Bootstrap Energi Core Node chaindata
+    ${command_pattern_console}
+        Attach to Energi Core Node or Monitor container
+    help
+        ${help_description}
+    ${command_pattern_setup}
+        Setup Energi Core Node container(s)
+    ${command_pattern_start}
+        Start Energi Core Node container(s); this is a shortcut for
+        \`docker-compose up --detach [${service_choices}]\`
+    ${command_pattern_status}
+        Energi Core Node synchronisation and staking status
+    ${command_pattern_update}
+        Update image(s) and recreate container(s).
+        Version argument (i.e. v3.1.0) can be used to build images and create
+        containers with \`energi3\` version other than the one that is specified
+        in \`${env_template}\`
 
 Available options:
-    -?, -h, --help  Print this help message
-\n"
-service_options_message="Valid options are:\
- no value or \`all\`; \`core\`; \`monitor\`."
+    -?, -h, --help
+        ${help_description}
+"
+service_arguments_message='Valid arguments are:
+  - no value or `all`;
+  - `core`;
+  - `monitor`.'
 exec='docker-compose exec'
 run='docker-compose run --rm'
 start='docker-compose start'
 stop='docker-compose stop'
 up='docker-compose up --detach'
 
-bootstrap_chaindata () {
+bootstrap_chaindata() {
   ${run} --entrypoint '/bin/sh bootstrap-chaindata.sh' core
 }
 
-setup_core () {
-  ${run}\
-    --entrypoint '/bin/sh /setup/setup.sh'\
-    --user=root\
-    --volume="${PWD}/setup:/setup"\
-    core && bootstrap_chaindata
-}
+check_max_arguments_count() {
+  count=${1}
+  max=${2}
+  pattern=${3}
 
-setup_monitor () {
-  ${run} --entrypoint='/bin/bash nodemon.sh' --user=root monitor
-}
+  if [ ${count} -gt ${max} ]; then
+    printf '%s\n' 'Too much arguments!'
 
-case "$1" in
-  '' )
-    printf 'No command or option was provided!\n\n'
-    printf '%b' "${help_message}"
-
-    exit 1 ;;
-  -? | -h | --help | help ) printf '%b' "${help_message}" ; exit 0 ;;
-  apply-preimages | preimages )
-    ${stop}
-    exit_code=$?
-    ${run} --entrypoint '/bin/sh apply-preimages.sh' core
-    exit_code=`expr $exit_code + $?`
-    ${up}
-    exit_code=`expr $exit_code + $?`
-
-    exit ${exit_code} ;;
-  attach )
-    ${exec} core energi3 --datadir /home/nrgstaker/.energicore3 attach
-
-    exit $? ;;
-  bootstrap-chaindata | chaindata )
-    ${stop}
-    exit_code=$?
-    bootstrap_chaindata && ${up}
-    exit_code=`expr $exit_code + $?`
-
-    exit exit_code ;;
-  setup )
-    case $2 in
-      '' | all )
-        setup_core && ${up} core && setup_monitor && ${up} monitor
-
-        exit $? ;;
-      core ) setup_core && ${up} core ; exit $? ;;
-      monitor ) setup_monitor && ${up} monitor ; exit $? ;;
-      * )
-        printf '`%b` is not a valid value for `setup`.\n' $2
-        printf '%b\n' "${service_options_message}"
-
-        exit 1
-    esac ;;
-  start )
-    case $2 in
-      '' | all ) ${up} ; exit $? ;;
-      core ) ${up} core ; exit $? ;;
-      monitor ) ${up} monitor ; exit $? ;;
-      * )
-        printf '`%b` is not a valid value for `start`.\n' $2
-        printf '%b\n' "${service_options_message}"
-
-        exit 1
-    esac ;;
-  status ) ${exec} core sh energi-core-node-status.sh ; exit $? ;;
-  update )
-    git pull
-    update="${up} --build --force-recreate"
-    case $2 in
-      '' | all ) ${update} ; exit $? ;;
-      core ) ${update} core ; exit $? ;;
-      monitor ) ${update} --no-deps monitor ; exit $? ;;
-      * )
-        printf '`%b` is not a valid value for `update`.\n' $2
-        printf '%b\n' "${service_options_message}"
-
-        exit 1
-    esac ;;
-  * )
-    printf "\`${1}\` is not a valid subcommand!\n\n"
-    printf '%b' "${help_message}"
+    if [ -n "${pattern}" ] && [ "${pattern}" != '' ]; then
+      printf "Subcommand's pattern is: %s\n" "${pattern}"
+    fi
 
     exit 1
+  fi
+}
+
+check_env() {
+  if [ ! -s ${env} ]; then
+    printf '`%s` does not exist or is empty. Creating it from `%s`.\n' \
+      ${env} ${env_template}
+    cat ${env_template} >${env}
+  fi
+}
+
+print_help_message() {
+  printf '%b' "\n${help_message}\n"
+}
+
+case "${1}" in
+'')
+  printf 'No command or option was provided!\n'
+  print_help_message
+
+  exit 1
+  ;;
+-? | -h | --help | help)
+  check_max_arguments_count ${#} 1 '-? | -h | --help | help'
+  print_help_message
+
+  exit 0
+  ;;
+apply-preimages | preimages)
+  check_max_arguments_count ${#} 1 "${command_pattern_preimages}"
+  check_env
+  ${stop}
+  exit_code=${?}
+  ${run} --entrypoint '/bin/sh apply-preimages.sh' core
+  exit_code=$(expr ${exit_code} + ${?})
+  ${up}
+  exit_code=$(expr ${exit_code} + ${?})
+
+  exit ${exit_code}
+  ;;
+attach)
+  check_max_arguments_count ${#} 1 "${command_pattern_attach}"
+  check_env
+  ${exec} core energi3 --datadir /home/nrgstaker/.energicore3 attach
+
+  exit ${?}
+  ;;
+bootstrap-chaindata | chaindata)
+  check_max_arguments_count ${#} 1 "${command_pattern_chaindata}"
+  check_env
+  ${stop}
+  exit_code=${?}
+  bootstrap_chaindata && ${up}
+  exit_code=$(expr $exit_code + ${?})
+
+  exit ${exit_code}
+  ;;
+console | shell | terminal)
+  check_max_arguments_count ${#} 2 "${command_pattern_console}"
+
+  if [ -z ${2} ] || [ "${2}" = '' ]; then
+    printf 'Service name (%s) is not provided!\n' "${service_choices}"
+
+    exit 1
+  fi
+
+  check_env
+
+  case "${2}" in
+  core)
+    ${exec} core /bin/sh
+
+    exit ${?}
+    ;;
+  monitor)
+    ${exec} monitor /bin/bash
+
+    exit ${?}
+    ;;
+  *)
+    printf '`%s` is not a valid service name!\n' ${2}
+    printf 'Valid options are: %s.\n' "${service_choices}"
+
+    exit 1
+    ;;
+  esac
+  ;;
+setup)
+  setup_monitor() {
+    ${run} --entrypoint='/bin/bash nodemon.sh' --user=root monitor
+  }
+
+  setup_core() {
+    ${run} \
+      --entrypoint '/bin/sh /setup/setup.sh' \
+      --user=root --volume="${PWD}/setup:/setup" \
+      core && bootstrap_chaindata
+  }
+
+  check_max_arguments_count ${#} 2 "${command_pattern_setup}"
+  check_env
+
+  case "${2}" in
+  '' | all)
+    setup_core && ${up} core && setup_monitor && ${up} monitor
+
+    exit ${?}
+    ;;
+  core)
+    setup_core && ${up} core
+
+    exit ${?}
+    ;;
+  monitor)
+    setup_monitor && ${up} monitor
+
+    exit ${?}
+    ;;
+  *)
+    printf '`%s` is not a valid argument for the subcommand `setup`.\n' ${2}
+    printf '%s\n' "${service_arguments_message}"
+
+    exit 1
+    ;;
+  esac
+  ;;
+start)
+  check_max_arguments_count ${#} 2 "${command_pattern_start}"
+  check_env
+
+  case "${2}" in
+  '' | all)
+    ${up}
+
+    exit ${?}
+    ;;
+  core)
+    ${up} core
+
+    exit ${?}
+    ;;
+  monitor)
+    ${up} monitor
+    exit ${?}
+    ;;
+  *)
+    printf '`%b` is not a valid argument for the subcommand `start`.\n' "${2}"
+    printf '%b\n' "${service_arguments_message}"
+
+    exit 1
+    ;;
+  esac
+  ;;
+staking-status | status)
+  check_max_arguments_count ${#} 1 "${command_pattern_status}"
+  check_env
+  ${exec} core sh energi-core-node-status.sh
+  exit ${?}
+  ;;
+update)
+  version_from_env() {
+    env=${1}
+    sed -n "s/${pattern_version_env}/\1/p" ${env}
+  }
+
+  case "${2}" in
+  all | core | monitor)
+    check_max_arguments_count ${#} 3 "${command_pattern_update}"
+    ;;
+  *) check_max_arguments_count ${#} 2 "${command_pattern_update}" ;;
+  esac
+
+  pattern_key='ENERGI_VERSION='
+  pattern_version='v[0-9]\+\.[0-9]\+\.[0-9]\+'
+  pattern_version_env="^${pattern_key}\(${pattern_version}\)$"
+  update="${up} --build"
+  command="${update}"
+  git pull
+
+  case "${2}" in
+  core) command="${update} core" ;;
+  monitor) command="${update} --no-deps monitor" ;;
+  esac
+
+  for last_argument in "${@}"; do :; done
+
+  case "${last_argument}" in
+  '' | all | core | monitor | update)
+    version=$(version_from_env ${env_template})
+    ;;
+  *)
+    version=$(printf '%s' ${last_argument} | grep ${pattern_version})
+
+    if [ -z ${version} ] || [ "${version}" = '' ]; then
+      printf 'Invalid version format!\n'
+      printf 'Version must be formatted like vX.Y.Z (for example: v3.1.0).\n'
+      printf 'Version provided: %s\n' "${last_argument}"
+
+      exit 1
+    fi
+    ;;
+  esac
+
+  check_env
+  current_version=$(version_from_env ${env})
+
+  if [ "${version}" != "${current_version}" ]; then
+    printf 'Current version %s differs from the provided one: %s.\n' \
+      "${current_version}" "${version}"
+    printf 'Updating it in `%s`.\n' ${env}
+    sed -i "s/^\(${pattern_key}\)${pattern_version}$/\1${version}/" ${env}
+  fi
+
+  ${command}
+
+  exit ${?}
+  ;;
+*)
+  printf '`%s` is not a valid subcommand!\n' "${1}"
+  print_help_message
+
+  exit 1
+  ;;
 esac

--- a/nodemon/Dockerfile
+++ b/nodemon/Dockerfile
@@ -1,12 +1,13 @@
 # Build the binary `energi3` in a stock Go builder container
 FROM golang:1.15-buster as energi3-builder
 
-RUN apt-get update\
- && apt-get install --assume-yes --no-install-recommends --quiet musl-dev\
- && apt-get clean;\
- git clone --branch v3.1.0 --depth 1\
-  https://github.com/energicryptocurrency/energi3.git energi3\
- && cd energi3 && make geth
+ARG ENERGI_VERSION
+
+RUN apt-get update \
+    && apt-get install --assume-yes --no-install-recommends --quiet musl-dev; \
+    git clone --branch ${ENERGI_VERSION} --depth 1 \
+    https://github.com/energicryptocurrency/energi3.git energi3 \
+    && cd energi3 && make geth
 
 
 # `ubuntu:latest` means "The latest Ubuntu LTS release"
@@ -20,23 +21,22 @@ ARG USER_HOME=/home/${USERNAME}
 ARG NODEMON_LOG_DIR=${USER_HOME}/log
 
 RUN DEBIAN_FRONTEND=noninteractive\
- apt-get update --quiet && apt-get upgrade --assume-yes --quiet &&\
- apt-get install --assume-yes --no-install-recommends --quiet\
-  bc ca-certificates curl debsums init jq logrotate ntpdate rkhunter sqlite3\
-  sudo wget;\
- apt-get clean all && rm --recursive --force /var/lib/apt/lists/*;\
- addgroup --gid ${USER_AND_GROUP_ID} ${USERNAME} &&\
- adduser\
-  --uid ${USER_AND_GROUP_ID} ${USERNAME}\
-  --ingroup ${USERNAME}\
-  --disabled-password\
-  --quiet;\
- usermod --append --groups sudo ${USERNAME};\
- mkdir --parents ${ECNM_DATA_DIR} &&\
- chown --recursive ${USERNAME} ${ECNM_DATA_DIR};\
- mkdir --parents ${NODEMON_LOG_DIR} && touch ${NODEMON_LOG_DIR}/nodemon.log &&\
- chown --recursive ${USERNAME}:${USERNAME} ${NODEMON_LOG_DIR};\
- touch /var/log/auth.log; touch /var/log/kern.log
+    apt-get update --quiet && apt-get upgrade --assume-yes --quiet \
+    && apt-get install --assume-yes --no-install-recommends --quiet \
+    bc ca-certificates curl debsums init jq logrotate ntpdate rkhunter sqlite3 \
+    sudo wget; \
+    apt-get clean all && rm --recursive --force /var/lib/apt/lists/*; \
+    addgroup --gid ${USER_AND_GROUP_ID} ${USERNAME} && adduser \
+    --uid ${USER_AND_GROUP_ID} ${USERNAME} \
+    --ingroup ${USERNAME} \
+    --disabled-password \
+    --quiet; \
+    usermod --append --groups sudo ${USERNAME}; \
+    mkdir --parents ${ECNM_DATA_DIR} \
+    && chown --recursive ${USERNAME} ${ECNM_DATA_DIR}; \
+    mkdir --parents ${NODEMON_LOG_DIR} && touch ${NODEMON_LOG_DIR}/nodemon.log \
+    && chown --recursive ${USERNAME}:${USERNAME} ${NODEMON_LOG_DIR}; \
+    touch /var/log/auth.log; touch /var/log/kern.log
 
 COPY --from=energi3-builder [ "/go/energi3/build/bin/energi3", "/usr/local/bin/" ]
 RUN [ "chmod", "+x", "/usr/local/bin/energi3" ]

--- a/nodemon/scripts/nodemon.sh
+++ b/nodemon/scripts/nodemon.sh
@@ -90,7 +90,7 @@ function CTRL_C () {
 
  # Set variables
  MNTOTALNRG=0
- USRNAME=$( find /home -name nodekey  2>&1 | grep -v "Permission denied" | awk -F\/ '{print $3}' )
+ USRNAME=$( find /home -name nrgstaker 2>&1 | grep -v "Permission denied" | awk -F\/ '{print $3}' )
  export PATH=$PATH:/home/${USRNAME}/energi3/bin
  LOGDIR="/home/${USRNAME}/log"
  LOGFILE="${LOGDIR}/nodemon.log"


### PR DESCRIPTION
Manual action is required for existing setups (see the last paragraph).

With these changes a single source of Energi Core Node version was
added: `.env` (and `.env.template.env`).

Helper script was updated to check if `.env` exists and to create it
with the content of `.env.template.env` when necessary. `update`
subcommand was updated to add the possibility to specify a version.

The main `ReadMe.md` was updated to describe the new functionality,
reformat its structure and update Energi documentation links.

After pulling these changes the following actions has to be done
manually for existing setups:

- `docker-compose.override.yml` must be updated:

  - `build: nodemon` must be replaced with

    ``` yml
        build:
          args:
            ENERGI_VERSION: ${ENERGI_VERSION}
          context: nodemon
    ```

  - `image: energi-nodemon:3.1.0-1.1.1-0.0` must be replaced with
    `image: energi-nodemon:${ENERGI_VERSION}-1.1.1-0.0`.

- if `.env` is existing, `ENERGI_VERSION=v3.1.0` must be added to it;
  if `.env` does not exist, it must be created by copying
  `env.template.env` and changing value for `COMPOSE_PROJECT_NAME` to
  the current stack name (the name of the directory this repository was
  cloned into (by default `energi3-docker-compose`)), otherwise `energi`
  will be used as the stack name and it most probably will differ from
  the current one meaning that Docker will unsuccessfully (Core Node
  creation will fail because of already used ports and missing keystore
  directory) try to create fresh containers and volumes.
