### PR TITLE
Specify correct permisison for `authorized_keys`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN addgroup --gid ${USER_AND_GROUP_ID} ${USERNAME} \
   chown -R ${USERNAME}:${USERNAME} ${STAKER_HOME}
 
 COPY --chown=${USERNAME}:${USERNAME} [ ".sshd", "${SSHD_DIR}/" ]
+RUN chmod 755 ${SSHD_DIR} && chmod 600 "${SSHD_DIR}/authorized_keys"
+
 COPY --chown=${USERNAME}:${USERNAME} [ "scripts", "./" ]
 
 USER ${USERNAME}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         ENERGI_VERSION: ${ENERGI_VERSION:?"}
         STAKER_HOME: ${STAKER_HOME:?}
       context: .
-    image: energi-core-node:${ENERGI_VERSION}-1.0
+    image: energi-core-node:${ENERGI_VERSION}-1.1
     ports:
       - 39797:39797/tcp
       - 39797:39797/udp


### PR DESCRIPTION
`Dockerfile` was updated to specify correct permissions for the directory `.sshd` and file `.sshd/authorized_keys` in staker user's home directory as too open permissions for `authorized_keys` may cause the error "Permission denied (publickey)" in some environments.

Fixes #31