### PR TITLE
Update GitHub repository path

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -212,6 +212,6 @@ A list of tools and sources used in this repository:
 - [Docker Compose](https://docs.docker.com/compose/);
 - [Energi Docker image](https://hub.docker.com/r/energicryptocurrency/energi)
   (source:
-  [Energi Core GitHub repository](https://github.com/energicryptocurrency/energi)
-  ([`containers/docker/master-alpine/Dockerfile`](https://github.com/energicryptocurrency/energi/blob/master/containers/docker/master-alpine/Dockerfile)));
+  [Energi Core GitHub repository](https://github.com/energicryptocurrency/go-energi)
+  ([`containers/docker/master-alpine/Dockerfile`](https://github.com/energicryptocurrency/go-energi/blob/master/containers/docker/master-alpine/Dockerfile)));
 - [Energi Core Node Monitor script `nodemon.sh`](https://github.com/energicryptocurrency/energi3-provisioning/blob/master/scripts/linux/nodemon.sh).

--- a/compose.override.template.yaml
+++ b/compose.override.template.yaml
@@ -12,7 +12,7 @@ services:
     env_file: nodemon/.env
     environment:
       - TERM=xterm
-    image: energi-node-monitor:${ENERGI_VERSION}-1.3.5-0.0
+    image: energi-node-monitor:${ENERGI_VERSION}-1.3.5-0.1
     restart: unless-stopped
     volumes:
       - target: "${ENERGI_CORE_DIR}"

--- a/nodemon/Dockerfile
+++ b/nodemon/Dockerfile
@@ -6,7 +6,7 @@ ARG ENERGI_VERSION
 RUN apt-get update \
   && apt-get install --assume-yes --no-install-recommends --quiet musl-dev; \
   git clone --branch ${ENERGI_VERSION} --depth 1 \
-    https://github.com/energicryptocurrency/energi.git energi \
+    https://github.com/energicryptocurrency/go-energi.git energi \
   && cd energi \
   && make geth
 

--- a/nodemon/scripts/nodemon.sh
+++ b/nodemon/scripts/nodemon.sh
@@ -76,7 +76,7 @@ DISCORD_WEBHOOK_USERNAME_DEFAULT='Energi Node Monitor'
 DISCORD_WEBHOOK_AVATAR_DEFAULT='https://i.imgur.com/8WHSSa7s.jpg'
 DISCORD_TITLE_LIMIT=266
 # NRG Parameters
-GITAPI_URL="https://api.github.com/repos/energicryptocurrency/energi/releases/latest"
+GITAPI_URL="https://api.github.com/repos/energicryptocurrency/go-energi/releases/latest"
 # Set variables
 MNTOTALNRG=0
 REMOVE_TRALING_DECIMAL_ZEROS_PATTERN='/\./ s/\.\?0\+$//'
@@ -2450,7 +2450,7 @@ Connections: ${GETCONNECTIONCOUNT}"
   fi
 
   # Check Github for URL of latest version
-  GIT_VERSION=$(curl -s ${GITAPI_URL} | jq -r '.tag_name')
+  GIT_VERSION=$(curl -s -L ${GITAPI_URL} | jq -r '.tag_name')
   # Extract latest version number without the 'v'
   GIT_LATEST="$(printf '%s' "${GIT_VERSION}" | sed 's/v//g')"
 


### PR DESCRIPTION
Additionally `nodemon/scripts/nodemon.sh` was updated to follow redirects when retrieving value for `GIT_VERSION` to prevent errors in case repository's URL gets changed again.